### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#EasyRecyclerViewSidebar
+# EasyRecyclerViewSidebar
 
 <br>
 
@@ -12,7 +12,7 @@
 <br>
 <br>
 
-##Introduction
+## Introduction
 
 EasyRecyclerViewSidebar is a more convenient sidebar index column.  
 
@@ -47,7 +47,7 @@ dependencies {
 <br>
 <br>
 
-##Listener
+## Listener
 
 You must implement the **EasyRecyclerViewSidebar.OnTouchSectionListener** .
 
@@ -209,7 +209,7 @@ private void initData() {
 <br>
 <br>
 
-##Screenshots
+## Screenshots
 
 <img src="https://github.com/CaMnter/EasyRecyclerViewSidebar/raw/master/screenshots/EasyRecyclerViewSidebar.gif" width="320x">   
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
